### PR TITLE
Add upgrade-triggered translation set refresh

### DIFF
--- a/angular-ui/src/app/components/translation-dashboard/translation-dashboard.component.html
+++ b/angular-ui/src/app/components/translation-dashboard/translation-dashboard.component.html
@@ -31,15 +31,19 @@
                     [ngClass]="{ 'selected': set.id === selectedLabelSet?.id }">
                         {{ set.name }}
                         <span class="pill pill-blue">{{ set.translationName }}</span>
-                        <mat-icon *ngIf="set.status === 'PROCESSING'"
-                                 matTooltip="Status: {{ set.status }}&#10;{{ set.percentageProcessed }}% complete"
+                        <mat-icon *ngIf="isTranslationSetInProgress(set.status)"
+                                 matTooltip="Status: {{ translationSetLifecycleStatusLabel(set.status) }}&#10;{{ set.percentageProcessed }}% complete"
+                                 matTooltipClass="multiline-tooltip"
+                                 class="processing-icon">schedule</mat-icon>
+                        <mat-icon *ngIf="set.status === 'QUEUED_FOR_UPGRADE' || set.status === 'INITIALISING'"
+                                 matTooltip="Status: {{ translationSetLifecycleStatusLabel(set.status) }}"
                                  matTooltipClass="multiline-tooltip"
                                  class="processing-icon">schedule</mat-icon>
                         <mat-icon *ngIf="set.status === 'FAILED'"
-                                matTooltip="Status: {{ set.status }}"
+                                matTooltip="Status: {{ translationSetLifecycleStatusLabel(set.status) }}"
                                 class="processing-icon">error</mat-icon>
                         <span *ngIf="set.size" class="artifact-info">{{ set.size }} concepts</span>
-                        <mat-progress-bar *ngIf="set.status === 'PROCESSING' && set.percentageProcessed !== undefined"
+                        <mat-progress-bar *ngIf="isTranslationSetInProgress(set.status) && set.percentageProcessed !== undefined"
                                          [value]="set.percentageProcessed"
                                          class="processing-progress-bar"></mat-progress-bar>
                     </mat-list-item>
@@ -64,12 +68,12 @@
 
                 <br><br>
                 <div>
-                    <div class="component-row" *ngIf="selectedLabelSet.status !== 'READY'">
+                    <div class="component-row" *ngIf="!isTranslationSetEditable(selectedLabelSet.status)">
                         <div class="component-col align-right">
                             <span class="details-field-name">Status</span>
                         </div>
                         <div class="component-col">
-                            <span class="details-field-value">{{ selectedLabelSet.status }}</span>
+                            <span class="details-field-value">{{ translationSetLifecycleStatusLabel(selectedLabelSet.status) }}</span>
                         </div>
                     </div>
                     <div class="component-row">
@@ -123,13 +127,13 @@
                 </div>
                 <br><br>
                 <div>
-                    <button mat-flat-button color="primary" *ngIf="selectedLabelSet.status === 'READY'"
+                    <button mat-flat-button color="primary" *ngIf="isTranslationSetEditable(selectedLabelSet.status)"
                             (click)="openWeblateUrl(selectedLabelSet.weblateLabelUrl)">
                         <mat-icon class="large-icon">translate</mat-icon>
                         Open in Translation Tool
                     </button>
 
-                    <button mat-stroked-button [matMenuTriggerFor]="actionsMenu" [disabled]="selectedLabelSet.status === 'PROCESSING'"
+                    <button mat-stroked-button [matMenuTriggerFor]="actionsMenu" [disabled]="isTranslationSetBusy(selectedLabelSet.status)"
                         style="margin-left: 10px;">
                         <mat-icon class="large-icon">more_vert</mat-icon>
                         Manage
@@ -140,30 +144,30 @@
                             <mat-icon class="large-icon">people</mat-icon>
                             Assign Work
                         </button> -->
-                        <button mat-menu-item (click)="setupAiTranslation()" [disabled]="selectedLabelSet.status === 'PROCESSING'"
+                        <button mat-menu-item (click)="setupAiTranslation()" [disabled]="isTranslationSetBusy(selectedLabelSet.status)"
                                 *ngIf="selectedLabelSet.status !== 'FAILED'">
                             <mat-icon class="large-icon">flash_on</mat-icon>
                             Setup AI Translation
                         </button>
                         <button mat-menu-item (click)="runAiBatchTranslation()"
-                                [disabled]="selectedLabelSet.status === 'PROCESSING'"
+                                [disabled]="isTranslationSetBusy(selectedLabelSet.status)"
                                 *ngIf="selectedLabelSet.status !== 'FAILED' && selectedLabelSet.aiSetupComplete">
                             <mat-icon class="large-icon">flash_on</mat-icon>
                             Run AI Translation
                         </button>
                         @if(!authoringPlatformMode && selectedLabelSet.status !== 'FAILED') {
-                            <button mat-menu-item (click)="pullFromWeblate()" [disabled]="selectedLabelSet.status === 'PROCESSING'">
+                            <button mat-menu-item (click)="pullFromWeblate()" [disabled]="isTranslationSetBusy(selectedLabelSet.status)">
                                 <mat-icon class="large-icon">cloud_download</mat-icon>
                                 Pull new translations from Translation Tool
                             </button>
                         }
-                        <button mat-menu-item (click)="refreshTranslationSet()" [disabled]="selectedLabelSet.status === 'PROCESSING' || refreshingSet"
+                        <button mat-menu-item (click)="refreshTranslationSet()" [disabled]="isTranslationSetBusy(selectedLabelSet.status) || refreshingSet"
                                 *ngIf="selectedLabelSet.status === 'READY' || selectedLabelSet.status === 'FAILED'">
                             <mat-icon class="large-icon">refresh</mat-icon>
                             Refresh Concept Selection in Translation Tool
                             <mat-spinner *ngIf="refreshingSet" [diameter]="16" class="button-spinner"></mat-spinner>
                         </button>
-                        <button mat-menu-item (click)="deleteTranslationSet()" [disabled]="selectedLabelSet.status === 'PROCESSING' || deleting">
+                        <button mat-menu-item (click)="deleteTranslationSet()" [disabled]="isTranslationSetBusy(selectedLabelSet.status) || deleting">
                             <mat-icon class="large-icon">cancel</mat-icon>
                             <span>Delete Set</span>
                             <mat-spinner *ngIf="deleting" [diameter]="16" class="button-spinner"></mat-spinner>
@@ -178,11 +182,11 @@
                 </div>
                 <br><br>
                 <h3>Translation Set Members</h3>
-                <div *ngIf="selectedLabelSet.status !== 'READY'" class="status-message">
+                <div *ngIf="!isTranslationSetEditable(selectedLabelSet.status)" class="status-message">
                     <p>Translation set members are only available when the set status is READY.</p>
-                    <p>Current status: <strong>{{ selectedLabelSet.status }}</strong></p>
+                    <p>Current status: <strong>{{ translationSetLifecycleStatusLabel(selectedLabelSet.status) }}</strong></p>
                 </div>
-                <mat-list id="members-list" class="sk-width" *ngIf="selectedLabelSet.status === 'READY'">
+                <mat-list id="members-list" class="sk-width" *ngIf="isTranslationSetEditable(selectedLabelSet.status)">
                     <div *ngIf="loadingLabelSetMembers">
                         <!-- Repeat this block for as many skeleton items as you want -->
                         <div class="skeleton-loader">

--- a/angular-ui/src/app/components/translation-dashboard/translation-dashboard.component.ts
+++ b/angular-ui/src/app/components/translation-dashboard/translation-dashboard.component.ts
@@ -11,6 +11,13 @@ import { AssignWorkDialogComponent } from '../assign-work-dialog/assign-work-dia
 import { SetupAiTranslationDialogComponent } from '../setup-ai-translation-dialog/setup-ai-translation-dialog.component';
 import { AiBatchTranslationDialogComponent } from '../ai-batch-translation-dialog/ai-batch-translation-dialog.component';
 import { ExportTaskDialogComponent } from '../export-task-dialog/export-task-dialog.component';
+import {
+    isTranslationSetBusy,
+    isTranslationSetEditable,
+    isTranslationSetInProgress,
+    isTranslationSetPolling,
+    translationSetLifecycleStatusLabel
+} from 'src/app/utils/translation-set-status';
 
 @Component({
     selector: 'app-translation-dashboard',
@@ -480,7 +487,7 @@ export class TranslationDashboardComponent implements OnInit, OnDestroy {
     }
 
     private managePolling() {
-        const hasProcessingSets = this.labelSets.some((set: any) => set.status === 'PROCESSING');
+        const hasProcessingSets = this.labelSets.some((set: any) => isTranslationSetPolling(set.status));
 
         if (hasProcessingSets && !this.isPolling) {
             this.startPolling();
@@ -488,6 +495,11 @@ export class TranslationDashboardComponent implements OnInit, OnDestroy {
             this.stopPolling();
         }
     }
+
+    isTranslationSetEditable = isTranslationSetEditable;
+    isTranslationSetBusy = isTranslationSetBusy;
+    isTranslationSetInProgress = isTranslationSetInProgress;
+    translationSetLifecycleStatusLabel = translationSetLifecycleStatusLabel;
 
     /**
      * Preserves detailed information (translated, changedSinceCreatedOrLastPulled) from existing data
@@ -564,8 +576,8 @@ export class TranslationDashboardComponent implements OnInit, OnDestroy {
                 // if they were previously loaded via the detailed API
                 const preservedLabelSets = this.preserveDetailedInformation(updatedLabelSets);
 
-                // Check if any sets have finished processing (changed from PROCESSING to READY)
-                const previouslyProcessingSets = this.labelSets.filter((set: any) => set.status === 'PROCESSING');
+                // Check if any sets have finished processing (changed from in-progress to READY)
+                const previouslyProcessingSets = this.labelSets.filter((set: any) => isTranslationSetInProgress(set.status));
                 const nowReadySets = preservedLabelSets.filter((set: any) => set.status === 'READY');
 
                 // Find sets that were processing and are now ready
@@ -664,7 +676,7 @@ export class TranslationDashboardComponent implements OnInit, OnDestroy {
         this.selectedLabelSet = labelSet;
 
         // Only load translation-set members if status is READY
-        if (labelSet.status === 'READY') {
+        if (isTranslationSetEditable(labelSet.status)) {
             this.loadLabelSetDetails(labelSet);
         } else {
             // Clear members if status is not READY

--- a/angular-ui/src/app/utils/translation-set-status.ts
+++ b/angular-ui/src/app/utils/translation-set-status.ts
@@ -1,0 +1,45 @@
+export function isTranslationSetEditable(status: string | null | undefined): boolean {
+	return status === 'READY';
+}
+
+export function isTranslationSetBusy(status: string | null | undefined): boolean {
+	return status === 'INITIALISING'
+		|| status === 'PROCESSING'
+		|| status === 'QUEUED_FOR_UPGRADE'
+		|| status === 'UPGRADING';
+}
+
+export function isTranslationSetPolling(status: string | null | undefined): boolean {
+	return isTranslationSetBusy(status);
+}
+
+export function translationSetLifecycleStatusLabel(status: string | null | undefined): string {
+	switch (status) {
+		case 'INITIALISING':
+			return 'Initialising';
+		case 'PROCESSING':
+			return 'Processing';
+		case 'QUEUED_FOR_UPGRADE':
+			return 'Queued for upgrade';
+		case 'UPGRADING':
+			return 'Upgrading';
+		case 'READY':
+			return 'Ready';
+		case 'FAILED':
+			return 'Failed';
+		case 'DELETING':
+			return 'Deleting';
+		default:
+			if (status == null || status === '') {
+				return 'Unknown';
+			}
+			return status
+				.replace(/_/g, ' ')
+				.toLowerCase()
+				.replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+}
+
+export function isTranslationSetInProgress(status: string | null | undefined): boolean {
+	return status === 'PROCESSING' || status === 'UPGRADING';
+}

--- a/api/src/main/java/org/snomed/simplex/rest/TranslationController.java
+++ b/api/src/main/java/org/snomed/simplex/rest/TranslationController.java
@@ -152,6 +152,15 @@ public class TranslationController {
 		return translationSets;
 	}
 
+	@PostMapping("{codeSystem}/translations/weblate-set/refresh-after-upgrade")
+	@Operation(summary = "Refresh all translation sets after a CodeSystem International Edition upgrade.",
+			description = "Queues refresh for all translation sets that need updating after the CodeSystem has been upgraded to a new International Edition version. " +
+				"Use this when the upgrade was performed outside Simplex. Sets already refreshed for the current dependant version are skipped.")
+	@PreAuthorize("hasPermission('AUTHOR', #codeSystem)")
+	public RefreshTranslationSetsAfterUpgradeResponse refreshWeblateSetsAfterUpgrade(@PathVariable String codeSystem) throws ServiceException {
+		return weblateSetService.refreshAllSetsAfterUpgrade(codeSystem);
+	}
+
 	@GetMapping("{codeSystem}/translations/{refsetId}/weblate-set")
 	@PreAuthorize("hasPermission('AUTHOR', #codeSystem)")
 	public List<WeblateTranslationSet> listWeblateSets(@PathVariable String codeSystem, @PathVariable String refsetId) {

--- a/api/src/main/java/org/snomed/simplex/rest/pojos/RefreshTranslationSetsAfterUpgradeResponse.java
+++ b/api/src/main/java/org/snomed/simplex/rest/pojos/RefreshTranslationSetsAfterUpgradeResponse.java
@@ -1,0 +1,12 @@
+package org.snomed.simplex.rest.pojos;
+
+import org.snomed.simplex.weblate.domain.WeblateTranslationSet;
+
+import java.util.List;
+
+public record RefreshTranslationSetsAfterUpgradeResponse(
+		int queued,
+		int skipped,
+		List<WeblateTranslationSet> sets
+) {
+}

--- a/api/src/main/java/org/snomed/simplex/service/external/UpgradeJobService.java
+++ b/api/src/main/java/org/snomed/simplex/service/external/UpgradeJobService.java
@@ -14,6 +14,7 @@ import org.snomed.simplex.rest.pojos.CodeSystemUpgradeRequest;
 import org.snomed.simplex.service.ActivityService;
 import org.snomed.simplex.service.SupportRegister;
 import org.snomed.simplex.service.job.ExternalServiceJob;
+import org.snomed.simplex.weblate.WeblateSetService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -27,16 +28,19 @@ import static org.snomed.simplex.service.CodeSystemService.setEditionStatus;
 public class UpgradeJobService extends ExternalFunctionJobService<CodeSystemUpgradeRequest> {
 
 	private final SnowstormClientFactory snowstormClientFactory;
+	private final WeblateSetService weblateSetService;
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	public UpgradeJobService(
 			SupportRegister supportRegister,
 			ActivityService activityService,
-			SnowstormClientFactory snowstormClientFactory) {
+			SnowstormClientFactory snowstormClientFactory,
+			WeblateSetService weblateSetService) {
 
 		super(supportRegister, activityService);
 		this.snowstormClientFactory = snowstormClientFactory;
+		this.weblateSetService = weblateSetService;
 	}
 
 	@Override
@@ -80,6 +84,9 @@ public class UpgradeJobService extends ExternalFunctionJobService<CodeSystemUpgr
 				snowstormClient.updateCodeSystem(codeSystem);
 				setEditionStatus(codeSystem, EditionStatus.AUTHORING, snowstormClient);
 				logger.info("Upgrade complete. Codesystem:{}", codeSystem.getShortName());
+				var refreshResult = weblateSetService.refreshAllSetsAfterUpgrade(codeSystem.getShortName());
+				logger.info("Post-upgrade translation set refresh for {}: queued {}, skipped {}",
+						codeSystem.getShortName(), refreshResult.queued(), refreshResult.skipped());
 				job.setStatus(JobStatus.COMPLETE);
 				upgradeComplete = true;
 			} else if (status == SnowstormUpgradeJob.Status.FAILED) {

--- a/api/src/main/java/org/snomed/simplex/weblate/WeblateSetService.java
+++ b/api/src/main/java/org/snomed/simplex/weblate/WeblateSetService.java
@@ -11,6 +11,7 @@ import org.snomed.simplex.exceptions.ServiceException;
 import org.snomed.simplex.exceptions.ServiceExceptionWithStatusCode;
 import org.snomed.simplex.rest.pojos.AssignWorkRequest;
 import org.snomed.simplex.rest.pojos.BatchTranslateRequest;
+import org.snomed.simplex.rest.pojos.RefreshTranslationSetsAfterUpgradeResponse;
 import org.snomed.simplex.service.SupportRegister;
 import org.snomed.simplex.service.job.ChangeSummary;
 import org.snomed.simplex.service.job.ContentJob;
@@ -147,6 +148,32 @@ public class WeblateSetService {
 	public WeblateTranslationSet refreshSet(WeblateTranslationSet translationSet) throws ServiceException {
 		creationService.refreshSet(translationSet);
 		return translationSet;
+	}
+
+	public RefreshTranslationSetsAfterUpgradeResponse refreshAllSetsAfterUpgrade(String codeSystem) throws ServiceException {
+		CodeSystem theCodeSystem = snowstormClientFactory.getClient().getCodeSystemOrThrow(codeSystem);
+		Integer currentDependantVersion = theCodeSystem.getDependantVersionEffectiveTime();
+
+		List<WeblateTranslationSet> queued = new ArrayList<>();
+		int skipped = 0;
+
+		for (WeblateTranslationSet set : weblateSetRepository.findByCodesystemOrderByName(codeSystem)) {
+			if (set.getStatus().isBusy()) {
+				skipped++;
+				continue;
+			}
+			if (set.getStatus() == TranslationSetStatus.READY
+					&& Objects.equals(currentDependantVersion, set.getInternationalEffectiveTime())) {
+				skipped++;
+				continue;
+			}
+			creationService.refreshSetForUpgrade(set);
+			queued.add(set);
+		}
+
+		logger.info("Queued {} translation sets for upgrade refresh on {}, skipped {}",
+				queued.size(), codeSystem, skipped);
+		return new RefreshTranslationSetsAfterUpgradeResponse(queued.size(), skipped, queued);
 	}
 
 	public WeblatePage<WeblateUnit> getSampleRows(WeblateTranslationSet translationSet, int pageSize) throws ServiceExceptionWithStatusCode {

--- a/api/src/main/java/org/snomed/simplex/weblate/domain/TranslationSetStatus.java
+++ b/api/src/main/java/org/snomed/simplex/weblate/domain/TranslationSetStatus.java
@@ -4,8 +4,18 @@ public enum TranslationSetStatus {
 
 	INITIALISING,
 	PROCESSING,
+	QUEUED_FOR_UPGRADE,
+	UPGRADING,
 	READY,
 	FAILED,
-	DELETING
+	DELETING;
+
+	public boolean isEditable() {
+		return this == READY;
+	}
+
+	public boolean isBusy() {
+		return this == INITIALISING || this == PROCESSING || this == QUEUED_FOR_UPGRADE || this == UPGRADING || this == DELETING;
+	}
 
 }

--- a/api/src/main/java/org/snomed/simplex/weblate/domain/WeblateTranslationSet.java
+++ b/api/src/main/java/org/snomed/simplex/weblate/domain/WeblateTranslationSet.java
@@ -61,6 +61,9 @@ public final class WeblateTranslationSet {
 	@Field(type = FieldType.Long)
 	private Date lastPulled;
 
+	@Field(type = FieldType.Integer)
+	private Integer internationalEffectiveTime;
+
 	@Transient
 	private String weblateLabelUrl;
 
@@ -226,6 +229,14 @@ public final class WeblateTranslationSet {
 
 	public void setLastPulled(Date lastPulled) {
 		this.lastPulled = lastPulled;
+	}
+
+	public Integer getInternationalEffectiveTime() {
+		return internationalEffectiveTime;
+	}
+
+	public void setInternationalEffectiveTime(Integer internationalEffectiveTime) {
+		this.internationalEffectiveTime = internationalEffectiveTime;
 	}
 
 	public int getChangedSinceCreatedOrLastPulled() {

--- a/api/src/main/java/org/snomed/simplex/weblate/sets/WeblateSetCreationService.java
+++ b/api/src/main/java/org/snomed/simplex/weblate/sets/WeblateSetCreationService.java
@@ -59,6 +59,7 @@ public class WeblateSetCreationService extends AbstractWeblateSetProcessingServi
 			throw new ServiceExceptionWithStatusCode("Language code not found for refset: " + refsetId, HttpStatus.NOT_FOUND);
 		}
 		translationSet.setLanguageCode(languageCode);
+		translationSet.setInternationalEffectiveTime(codeSystem.getDependantVersionEffectiveTime());
 
 		WeblateAdminClient weblateAdminClient = weblateClientFactory.getAdminClient();
 		if (!weblateAdminClient.isTranslationExistsSearchByLanguageRefset(translationSet.getLanguageCodeWithRefsetId())) {
@@ -76,9 +77,12 @@ public class WeblateSetCreationService extends AbstractWeblateSetProcessingServi
 	}
 
 	public void refreshSet(WeblateTranslationSet translationSet) throws ServiceException {
-		if (translationSet.getStatus() == TranslationSetStatus.DELETING) {
-			throw new ServiceExceptionWithStatusCode("Cannot refresh a translation set that is being deleted.", HttpStatus.CONFLICT);
+		if (translationSet.getStatus().isBusy()) {
+			throw new ServiceExceptionWithStatusCode("Cannot refresh a translation set that is being processed.", HttpStatus.CONFLICT);
 		}
+
+		CodeSystem codeSystem = snowstormClientFactory.getClient().getCodeSystemOrThrow(translationSet.getCodesystem());
+		translationSet.setInternationalEffectiveTime(codeSystem.getDependantVersionEffectiveTime());
 
 		translationSet.setStatus(TranslationSetStatus.INITIALISING);
 		translationSet.setPercentageProcessed(PERCENTAGE_PROCESSED_START);
@@ -89,10 +93,31 @@ public class WeblateSetCreationService extends AbstractWeblateSetProcessingServi
 		queueJob(translationSet, JOB_TYPE_REFRESH);
 	}
 
+	public void refreshSetForUpgrade(WeblateTranslationSet translationSet) throws ServiceException {
+		if (translationSet.getStatus().isBusy()) {
+			throw new ServiceExceptionWithStatusCode("Cannot refresh a translation set that is being processed.", HttpStatus.CONFLICT);
+		}
+
+		CodeSystem codeSystem = snowstormClientFactory.getClient().getCodeSystemOrThrow(translationSet.getCodesystem());
+		translationSet.setInternationalEffectiveTime(codeSystem.getDependantVersionEffectiveTime());
+
+		translationSet.setStatus(TranslationSetStatus.QUEUED_FOR_UPGRADE);
+		translationSet.setPercentageProcessed(PERCENTAGE_PROCESSED_START);
+
+		logger.info("Queueing Translation Tool Translation Set for upgrade refresh {}/{}/{}",
+				translationSet.getCodesystem(), translationSet.getRefset(), translationSet.getLabel());
+		weblateSetRepository.save(translationSet);
+
+		queueJob(translationSet, JOB_TYPE_REFRESH);
+	}
+
 	public void doRefreshSet(WeblateTranslationSet translationSet, WeblateAdminClient weblateAdminClient, SnowstormClientFactory snowstormClientFactory) throws ServiceExceptionWithStatusCode {
 		TimerUtil timerUtil = new TimerUtil("Refreshing label %s".formatted(translationSet.getLabel()));
 
-		translationSet.setStatus(TranslationSetStatus.PROCESSING);
+		TranslationSetStatus inProgressStatus = translationSet.getStatus() == TranslationSetStatus.QUEUED_FOR_UPGRADE
+				? TranslationSetStatus.UPGRADING
+				: TranslationSetStatus.PROCESSING;
+		translationSet.setStatus(inProgressStatus);
 		weblateSetRepository.save(translationSet);
 
 		// Fetch current concept IDs that have this label in Weblate using a CSV download for performance

--- a/api/src/test/java/org/snomed/simplex/weblate/WeblateSetServiceUpgradeRefreshTest.java
+++ b/api/src/test/java/org/snomed/simplex/weblate/WeblateSetServiceUpgradeRefreshTest.java
@@ -1,0 +1,99 @@
+package org.snomed.simplex.weblate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.snomed.simplex.client.SnowstormClient;
+import org.snomed.simplex.client.SnowstormClientFactory;
+import org.snomed.simplex.client.domain.CodeSystem;
+import org.snomed.simplex.exceptions.ServiceException;
+import org.snomed.simplex.rest.pojos.RefreshTranslationSetsAfterUpgradeResponse;
+import org.snomed.simplex.service.SupportRegister;
+import org.snomed.simplex.translation.service.TranslationService;
+import org.snomed.simplex.weblate.domain.TranslationSetStatus;
+import org.snomed.simplex.weblate.domain.TranslationSubsetType;
+import org.snomed.simplex.weblate.domain.WeblateTranslationSet;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.jms.core.JmsTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WeblateSetServiceUpgradeRefreshTest {
+
+	private WeblateSetRepository repository;
+	private SnowstormClientFactory snowstormClientFactory;
+	private SnowstormClient snowstormClient;
+	private CodeSystem codeSystem;
+	private WeblateSetService service;
+
+	@BeforeEach
+	void setUp() {
+		repository = mock(WeblateSetRepository.class);
+		snowstormClientFactory = mock(SnowstormClientFactory.class);
+		snowstormClient = mock(SnowstormClient.class);
+		codeSystem = mock(CodeSystem.class);
+		when(snowstormClientFactory.getClient()).thenReturn(snowstormClient);
+		when(snowstormClient.getCodeSystemOrThrow("TEST")).thenReturn(codeSystem);
+		when(codeSystem.getDependantVersionEffectiveTime()).thenReturn(20250701);
+
+		service = new WeblateSetService(repository, mock(WeblateClientFactory.class), snowstormClientFactory,
+				mock(TranslationService.class), mock(SupportRegister.class), mock(TranslationLLMService.class),
+				mock(JmsTemplate.class), "default", 100, new ObjectMapper());
+	}
+
+	@Test
+	void refreshAllSetsAfterUpgrade_queuesOutdatedSets() throws ServiceException {
+		WeblateTranslationSet outdated = setWithStatus(TranslationSetStatus.READY, 20250101);
+		WeblateTranslationSet current = setWithStatus(TranslationSetStatus.READY, 20250701);
+		WeblateTranslationSet busy = setWithStatus(TranslationSetStatus.UPGRADING, 20250101);
+		when(repository.findByCodesystemOrderByName("TEST")).thenReturn(List.of(outdated, current, busy));
+
+		RefreshTranslationSetsAfterUpgradeResponse response = service.refreshAllSetsAfterUpgrade("TEST");
+
+		assertThat(response.queued()).isEqualTo(1);
+		assertThat(response.skipped()).isEqualTo(2);
+		assertThat(response.sets()).hasSize(1);
+		assertThat(outdated.getStatus()).isEqualTo(TranslationSetStatus.QUEUED_FOR_UPGRADE);
+		assertThat(outdated.getInternationalEffectiveTime()).isEqualTo(20250701);
+		verify(repository).save(outdated);
+	}
+
+	@Test
+	void refreshAllSetsAfterUpgrade_queuesFailedSetsWithOutdatedVersion() throws ServiceException {
+		WeblateTranslationSet failed = setWithStatus(TranslationSetStatus.FAILED, 20250101);
+		when(repository.findByCodesystemOrderByName("TEST")).thenReturn(List.of(failed));
+
+		RefreshTranslationSetsAfterUpgradeResponse response = service.refreshAllSetsAfterUpgrade("TEST");
+
+		assertThat(response.queued()).isEqualTo(1);
+		assertThat(response.skipped()).isZero();
+		assertThat(failed.getStatus()).isEqualTo(TranslationSetStatus.QUEUED_FOR_UPGRADE);
+	}
+
+	@Test
+	void refreshAllSetsAfterUpgrade_skipsReadySetsAtCurrentVersion() throws ServiceException {
+		WeblateTranslationSet current = setWithStatus(TranslationSetStatus.READY, 20250701);
+		when(repository.findByCodesystemOrderByName("TEST")).thenReturn(List.of(current));
+
+		RefreshTranslationSetsAfterUpgradeResponse response = service.refreshAllSetsAfterUpgrade("TEST");
+
+		assertThat(response.queued()).isZero();
+		assertThat(response.skipped()).isEqualTo(1);
+		verify(repository, never()).save(any());
+	}
+
+	private WeblateTranslationSet setWithStatus(TranslationSetStatus status, Integer internationalEffectiveTime) {
+		WeblateTranslationSet set = new WeblateTranslationSet("TEST", "123456789012345678", "Test Set", "test-set",
+				"<< 138875005", TranslationSubsetType.SUB_TYPE, "TEST");
+		set.setLanguageCode("fr");
+		set.setStatus(status);
+		set.setInternationalEffectiveTime(internationalEffectiveTime);
+		return set;
+	}
+}

--- a/api/src/test/java/org/snomed/simplex/weblate/domain/TranslationSetStatusTest.java
+++ b/api/src/test/java/org/snomed/simplex/weblate/domain/TranslationSetStatusTest.java
@@ -1,0 +1,27 @@
+package org.snomed.simplex.weblate.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TranslationSetStatusTest {
+
+	@Test
+	void isEditable_onlyReady() {
+		assertThat(TranslationSetStatus.READY.isEditable()).isTrue();
+		assertThat(TranslationSetStatus.PROCESSING.isEditable()).isFalse();
+		assertThat(TranslationSetStatus.QUEUED_FOR_UPGRADE.isEditable()).isFalse();
+		assertThat(TranslationSetStatus.UPGRADING.isEditable()).isFalse();
+	}
+
+	@Test
+	void isBusy_includesProcessingStates() {
+		assertThat(TranslationSetStatus.INITIALISING.isBusy()).isTrue();
+		assertThat(TranslationSetStatus.PROCESSING.isBusy()).isTrue();
+		assertThat(TranslationSetStatus.QUEUED_FOR_UPGRADE.isBusy()).isTrue();
+		assertThat(TranslationSetStatus.UPGRADING.isBusy()).isTrue();
+		assertThat(TranslationSetStatus.DELETING.isBusy()).isTrue();
+		assertThat(TranslationSetStatus.READY.isBusy()).isFalse();
+		assertThat(TranslationSetStatus.FAILED.isBusy()).isFalse();
+	}
+}

--- a/api/src/test/java/org/snomed/simplex/weblate/sets/WeblateSetCreationServiceTest.java
+++ b/api/src/test/java/org/snomed/simplex/weblate/sets/WeblateSetCreationServiceTest.java
@@ -1,0 +1,152 @@
+package org.snomed.simplex.weblate.sets;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.snomed.simplex.client.SnowstormClient;
+import org.snomed.simplex.client.SnowstormClientFactory;
+import org.snomed.simplex.client.domain.CodeSystem;
+import org.snomed.simplex.exceptions.ServiceException;
+import org.snomed.simplex.exceptions.ServiceExceptionWithStatusCode;
+import org.snomed.simplex.weblate.WeblateAdminClient;
+import org.snomed.simplex.weblate.WeblateClient;
+import org.snomed.simplex.weblate.WeblateClientFactory;
+import org.snomed.simplex.weblate.WeblateSetRepository;
+import org.snomed.simplex.weblate.TranslationLLMService;
+import org.snomed.simplex.weblate.domain.TranslationSetStatus;
+import org.snomed.simplex.weblate.domain.TranslationSubsetType;
+import org.snomed.simplex.weblate.domain.WeblateTranslationSet;
+import org.springframework.http.HttpStatus;
+import org.springframework.jms.core.JmsTemplate;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WeblateSetCreationServiceTest {
+
+	@Test
+	void refreshSetForUpgrade_setsQueuedForUpgradeAndQueuesJob() throws ServiceException {
+		WeblateSetRepository repository = mock();
+		SnowstormClientFactory snowstormClientFactory = mock();
+		SnowstormClient snowstormClient = mock();
+		CodeSystem codeSystem = mock();
+		when(snowstormClientFactory.getClient()).thenReturn(snowstormClient);
+		when(snowstormClient.getCodeSystemOrThrow("TEST")).thenReturn(codeSystem);
+		when(codeSystem.getDependantVersionEffectiveTime()).thenReturn(20250701);
+
+		WeblateSetCreationService service = createService(repository, snowstormClientFactory);
+		WeblateTranslationSet set = readySet();
+
+		service.refreshSetForUpgrade(set);
+
+		assertThat(set.getStatus()).isEqualTo(TranslationSetStatus.QUEUED_FOR_UPGRADE);
+		assertThat(set.getInternationalEffectiveTime()).isEqualTo(20250701);
+		verify(repository).save(set);
+	}
+
+	@Test
+	void refreshSetForUpgrade_rejectsBusySet() {
+		WeblateSetRepository repository = mock();
+		SnowstormClientFactory snowstormClientFactory = mock();
+		WeblateSetCreationService service = createService(repository, snowstormClientFactory);
+		WeblateTranslationSet set = readySet();
+		set.setStatus(TranslationSetStatus.UPGRADING);
+
+		assertThatThrownBy(() -> service.refreshSetForUpgrade(set))
+				.isInstanceOf(ServiceExceptionWithStatusCode.class)
+				.extracting("httpStatus")
+				.isEqualTo(HttpStatus.CONFLICT);
+	}
+
+	@Test
+	void doRefreshSet_transitionsQueuedForUpgradeToUpgradingThenReady() throws ServiceExceptionWithStatusCode {
+		WeblateSetRepository repository = mock();
+		WeblateClientFactory weblateClientFactory = mock();
+		WeblateClient weblateClient = mock();
+		WeblateAdminClient weblateAdminClient = mock();
+		when(weblateClientFactory.getClient()).thenReturn(weblateClient);
+		when(weblateClient.getConceptIdsInWeblateSet(any())).thenReturn(new HashSet<>());
+
+		SnowstormClientFactory snowstormClientFactory = mock();
+		SnowstormClient snowstormClient = mock();
+		CodeSystem selectionCodeSystem = mock();
+		when(snowstormClientFactory.getClient()).thenReturn(snowstormClient);
+		when(snowstormClient.getCodeSystemOrThrow("TEST")).thenReturn(selectionCodeSystem);
+		when(selectionCodeSystem.getBranchPath()).thenReturn("MAIN");
+
+		SnowstormClient.ConceptIdStream conceptIdStream = mock();
+		when(snowstormClient.getConceptIdStream(eq("MAIN"), any())).thenReturn(conceptIdStream);
+		when(conceptIdStream.get()).thenReturn(null);
+		when(conceptIdStream.getTotal()).thenReturn(0);
+
+		when(weblateAdminClient.getCreateLabel(any(), any(), any())).thenReturn(mock());
+
+		WeblateSetCreationService service = createService(repository, snowstormClientFactory, weblateClientFactory);
+		WeblateTranslationSet set = readySet();
+		set.setStatus(TranslationSetStatus.QUEUED_FOR_UPGRADE);
+
+		service.doRefreshSet(set, weblateAdminClient, snowstormClientFactory);
+
+		assertThat(set.getStatus()).isEqualTo(TranslationSetStatus.READY);
+		assertThat(set.getPercentageProcessed()).isEqualTo(100);
+	}
+
+	@Test
+	void doRefreshSet_transitionsInitialisingToProcessingThenReady() throws ServiceExceptionWithStatusCode {
+		WeblateSetRepository repository = mock();
+		WeblateClientFactory weblateClientFactory = mock();
+		WeblateClient weblateClient = mock();
+		WeblateAdminClient weblateAdminClient = mock();
+		when(weblateClientFactory.getClient()).thenReturn(weblateClient);
+		when(weblateClient.getConceptIdsInWeblateSet(any())).thenReturn(new HashSet<>());
+
+		SnowstormClientFactory snowstormClientFactory = mock();
+		SnowstormClient snowstormClient = mock();
+		CodeSystem selectionCodeSystem = mock();
+		when(snowstormClientFactory.getClient()).thenReturn(snowstormClient);
+		when(snowstormClient.getCodeSystemOrThrow("TEST")).thenReturn(selectionCodeSystem);
+		when(selectionCodeSystem.getBranchPath()).thenReturn("MAIN");
+
+		SnowstormClient.ConceptIdStream conceptIdStream = mock();
+		when(snowstormClient.getConceptIdStream(eq("MAIN"), any())).thenReturn(conceptIdStream);
+		when(conceptIdStream.get()).thenReturn(null);
+		when(conceptIdStream.getTotal()).thenReturn(0);
+
+		when(weblateAdminClient.getCreateLabel(any(), any(), any())).thenReturn(mock());
+
+		WeblateSetCreationService service = createService(repository, snowstormClientFactory, weblateClientFactory);
+		WeblateTranslationSet set = readySet();
+		set.setStatus(TranslationSetStatus.INITIALISING);
+
+		service.doRefreshSet(set, weblateAdminClient, snowstormClientFactory);
+
+		assertThat(set.getStatus()).isEqualTo(TranslationSetStatus.READY);
+	}
+
+	private WeblateSetCreationService createService(WeblateSetRepository repository, SnowstormClientFactory snowstormClientFactory) {
+		return createService(repository, snowstormClientFactory, mock(WeblateClientFactory.class));
+	}
+
+	private WeblateSetCreationService createService(WeblateSetRepository repository, SnowstormClientFactory snowstormClientFactory,
+			WeblateClientFactory weblateClientFactory) {
+		ProcessingContext ctx = new ProcessingContext(snowstormClientFactory, weblateClientFactory, repository,
+				mock(TranslationLLMService.class), new HashMap<>(), mock(JmsTemplate.class), "test-queue", new ObjectMapper());
+		return new WeblateSetCreationService(ctx, 100);
+	}
+
+	private WeblateTranslationSet readySet() {
+		WeblateTranslationSet set = new WeblateTranslationSet("TEST", "123456789012345678", "Test Set", "test-set",
+				"<< 138875005", TranslationSubsetType.SUB_TYPE, "TEST");
+		set.setLanguageCode("fr");
+		set.setStatus(TranslationSetStatus.READY);
+		set.setInternationalEffectiveTime(20250101);
+		return set;
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a CodeSystem is upgraded to a new International Edition version, all translation sets for that CodeSystem must be refreshed. This change adds:

- **New set statuses** `QUEUED_FOR_UPGRADE` and `UPGRADING`, behaving like `INITIALISING` and `PROCESSING` (blocking editing)
- **REST endpoint** `POST api/{codeSystem}/translations/weblate-set/refresh-after-upgrade` for triggering refresh after external upgrades
- **Automatic refresh** after Simplex upgrade completes (`UpgradeJobService`)
- **Dashboard updates** for polling, labels, and edit blocking during upgrade refresh

## Behaviour

- Upgrade-triggered refresh uses `QUEUED_FOR_UPGRADE` → `UPGRADING` → `READY`
- Manual single-set refresh continues to use `INITIALISING` → `PROCESSING` → `READY`
- Bulk refresh skips sets that are busy or already refreshed for the current dependant version
- Sets store `internationalEffectiveTime` to track the International Edition version at last create/refresh

## Testing

Added unit tests for:
- `TranslationSetStatus` helper methods
- `WeblateSetCreationService.refreshSetForUpgrade()` and status transitions in `doRefreshSet()`
- `WeblateSetService.refreshAllSetsAfterUpgrade()` queuing and skipping logic
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbbe8ac6-6f18-404a-8641-c9bc9b351638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbbe8ac6-6f18-404a-8641-c9bc9b351638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

